### PR TITLE
fixing issue that the filter result text is ugly positioned

### DIFF
--- a/euth/dashboard/templates/euth_dashboard/project_list.html
+++ b/euth/dashboard/templates/euth_dashboard/project_list.html
@@ -19,7 +19,7 @@
 
 <div class="dashboard-projects-list">
     {% if project_list|length == 0 %}
-    <div>
+    <div class="infotext">
       {% trans 'No projects found' %}
     </div>
 

--- a/euth/dashboard/templates/euth_dashboard/project_list.html
+++ b/euth/dashboard/templates/euth_dashboard/project_list.html
@@ -19,8 +19,12 @@
 
 <div class="dashboard-projects-list">
     {% if project_list|length == 0 %}
-    {% trans 'No projects created' %}
+    <div>
+      {% trans 'No projects found' %}
+    </div>
+
     {% else %}
+
     <ul>
         {% for project in project_list %}
             <li class="tile-list project-tile-list">

--- a/euth_wagtail/assets/scss/components/_dashboard.scss
+++ b/euth_wagtail/assets/scss/components/_dashboard.scss
@@ -41,7 +41,6 @@ h1.dashboard-title {
 
 
 .dashboard-projects-list {
-
     .infotext {
         @include rem(margin, 20px 0);
         padding-left: 0;
@@ -55,7 +54,6 @@ h1.dashboard-title {
     & form {
         display: inline-block;
     }
-
 }
 
 .dashboard-project-controls {

--- a/euth_wagtail/assets/scss/components/_dashboard.scss
+++ b/euth_wagtail/assets/scss/components/_dashboard.scss
@@ -41,6 +41,12 @@ h1.dashboard-title {
 
 
 .dashboard-projects-list {
+
+    &> div {
+        @include rem(margin, 20px 0);
+        padding-left: 0;
+    }
+
     ul {
         @include rem(margin, 20px 0);
         padding-left: 0;

--- a/euth_wagtail/assets/scss/components/_dashboard.scss
+++ b/euth_wagtail/assets/scss/components/_dashboard.scss
@@ -42,7 +42,7 @@ h1.dashboard-title {
 
 .dashboard-projects-list {
 
-    &> div {
+    .infotext {
         @include rem(margin, 20px 0);
         padding-left: 0;
     }

--- a/euth_wagtail/assets/scss/components/forms/_general-form.scss
+++ b/euth_wagtail/assets/scss/components/forms/_general-form.scss
@@ -67,7 +67,6 @@
             content: "\f05A ";
         }
     }
-
 }
 
 .form-help-text {


### PR DESCRIPTION
As seen in issue #815 the text `Keine Projekte erstellt` is ugly positioned. This PR fixes this.