### PR TITLE
Ka 2017 05 user timezone datepicker

### DIFF
--- a/euth/contrib/static/js/dateTimeInput.js
+++ b/euth/contrib/static/js/dateTimeInput.js
@@ -1,11 +1,2 @@
 /* global $ */
-$('.flatpickr').flatpickr({
-  onChange: function (selectedDates, dateStr, instance) {
-    var newDate = instance.formatDate(instance.config.dateFormat, selectedDates[0].fp_toUTC())
-    $(instance.element).val(newDate)
-  },
-  onReady: function (selectedDates, dateStr, instance) {
-    var newDate = instance.formatDate(instance.config.dateFormat, selectedDates[0].fp_toUTC())
-    $(instance.element).val(newDate)
-  }
-})
+$('.flatpickr').flatpickr()

--- a/euth/contrib/widgets.py
+++ b/euth/contrib/widgets.py
@@ -10,7 +10,6 @@ from django.template.loader import render_to_string
 from django.utils import formats
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
-from django.utils.translation import get_language
 
 
 class DateInput(widgets.DateInput):
@@ -22,6 +21,7 @@ class DateInput(widgets.DateInput):
 
     input_type = 'text'
     format_index = 0
+    # alt_format_index = 2
 
     # becomes a public value in Django 1.10
     def _format_value(self, value):
@@ -37,11 +37,14 @@ class DateInput(widgets.DateInput):
             format = formats.get_format(
                 self.format_key
             )[self.format_index]
+            # alt_format = formats.get_format(
+            #     self.format_key
+            # )[self.alt_format_index]
             attrs.update({
                 'class': attrs.get('class', '') + ' flatpickr',
-                'data-language': get_language(),
-                'data-alt-format': format.replace('%', '').replace('M', 'i'),
                 'data-date-format': format.replace('%', '').replace('M', 'i'),
+                # 'data-alt-format': alt_format.replace(
+                # '%', '').replace('M', 'i'),
             })
 
             if hasattr(self, 'additional_attrs'):
@@ -61,10 +64,11 @@ class DateTimeInput(DateInput):
     additional_attrs = {
         'data-time_24hr': 'true',
         'data-enable-time': 'true',
-        'data-alt-input': 'true'
+        # 'data-alt-input': 'true'
     }
 
-    format_index = 2
+    format_index = 0
+    # alt_format_index = 2
     format_key = 'DATETIME_INPUT_FORMATS'
 
 

--- a/euth/contrib/widgets.py
+++ b/euth/contrib/widgets.py
@@ -20,21 +20,15 @@ class DateInput(widgets.DateInput):
 
     input_type = 'text'
     format_index = 0
-    # alt_format_index = 2
 
     def render(self, name, value, attrs=None):
         if attrs:
             format = formats.get_format(
                 self.format_key
             )[self.format_index]
-            # alt_format = formats.get_format(
-            #     self.format_key
-            # )[self.alt_format_index]
             attrs.update({
                 'class': attrs.get('class', '') + ' flatpickr',
                 'data-date-format': format.replace('%', '').replace('M', 'i'),
-                # 'data-alt-format': alt_format.replace(
-                # '%', '').replace('M', 'i'),
             })
 
             if hasattr(self, 'additional_attrs'):
@@ -54,11 +48,9 @@ class DateTimeInput(DateInput):
     additional_attrs = {
         'data-time_24hr': 'true',
         'data-enable-time': 'true',
-        # 'data-alt-input': 'true'
     }
 
     format_index = 0
-    # alt_format_index = 2
     format_key = 'DATETIME_INPUT_FORMATS'
 
 

--- a/euth/contrib/widgets.py
+++ b/euth/contrib/widgets.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from itertools import chain
 
 import django_filters
@@ -22,15 +21,6 @@ class DateInput(widgets.DateInput):
     input_type = 'text'
     format_index = 0
     # alt_format_index = 2
-
-    # becomes a public value in Django 1.10
-    def _format_value(self, value):
-        format = formats.get_format(self.format_key)[self.format_index]
-        if isinstance(value, str):
-            date = datetime.strptime(value, format)
-            return date.strftime('%Y-%m-%dT%H:%M:%S.%f%zZ')
-        else:
-            return value.strftime('%Y-%m-%dT%H:%M:%S.%f%zZ')
 
     def render(self, name, value, attrs=None):
         if attrs:

--- a/euth/dashboard/forms.py
+++ b/euth/dashboard/forms.py
@@ -10,7 +10,8 @@ from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db.models import loading
 from django.forms import modelformset_factory
-from django.utils.translation import ugettext as _
+from django.utils import timezone
+from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4.modules import models as module_models
 from adhocracy4.phases import models as phase_models
@@ -170,6 +171,20 @@ class PhaseForm(forms.ModelForm):
             'type': forms.HiddenInput(),
             'weight': forms.HiddenInput()
         }
+
+        help_texts = {
+            'start_date': _('Your timezone: {}'),
+            'end_date': _('Your timezone: {}'),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['start_date'].help_text = \
+            self.fields['start_date'].help_text.format(
+            timezone.get_current_timezone())
+        self.fields['end_date'].help_text = \
+            self.fields['end_date'].help_text.format(
+            timezone.get_current_timezone())
 
 
 def get_module_settings_form(settings_instance_or_modelref):

--- a/euth/dashboard/static/add_offline_phase/add_offline_phase.js
+++ b/euth/dashboard/static/add_offline_phase/add_offline_phase.js
@@ -5,7 +5,6 @@ window.jQuery(document).ready(function () {
     element.find('#id_phases-0-type').val('euth_offlinephases:000:offline')
     element.find('#id_phases-0-delete').val(0)
     element.find('.collapse').eq(0).text(django.gettext('Offline Phase')).append('<i class="fa fa-chevron-up pull-right"></i>')
-    element.find(('[type=text][readonly]')).remove()
     element.css('display', 'block')
 
     var button = getButton(element)

--- a/euth/dashboard/templates/euth_dashboard/includes/project_form_participation_tab.html
+++ b/euth/dashboard/templates/euth_dashboard/includes/project_form_participation_tab.html
@@ -59,10 +59,10 @@
                         <div class="form-group {% if field.errors %} has-error{% endif %}">
                             <label>
                                 {{ field.label }} {% trans 'of Phase '%}: <br />
-                                {% if field.help_text %}
-                                <p><i>{{ field.help_text }}</i></p>
-                                {% endif %}
                             </label>
+                            {% if field.help_text %}
+                                <p class="form-help-text"><i>{{ field.help_text }}</i></p>
+                            {% endif %}
                             {% render_field field class="form-control" %}
                             {% for error in field.errors %}
                             <span class="help-block">{{ error }}</span>
@@ -76,10 +76,10 @@
                                 <div class="form-group {% if form.start_date.errors %} has-error{% endif %}">
                                     <label>
                                         {{ form.start_date.label }} {% trans 'of Phase '%}:</br>
-                                        {% if form.start_date.help_text %}
-                                        <i>{{ form.start_date.help_text }}</i><br />
-                                        {% endif %}
                                     </label>
+                                    {% if form.start_date.help_text %}
+                                        <p class="form-help-text"><i>{{ form.start_date.help_text }}</i></p>
+                                    {% endif %}
                                     {% render_field form.start_date class="form-control" %}
                                     {% for error in form.start_date.errors %}
                                     <span class="help-block">{{ error }}</span>
@@ -90,10 +90,10 @@
                                 <div class="form-group {% if form.end_date.errors %} has-error{% endif %}">
                                     <label>
                                         {{ form.end_date.label }} {% trans 'of Phase '%}:<br />
-                                        {% if form.end_date.help_text %}
-                                        <i>{{ form.end_date.help_text }}</i><br />
-                                        {% endif %}
                                     </label>
+                                    {% if form.end_date.help_text %}
+                                        <p class="form-help-text"><i>{{ form.end_date.help_text }}</i></p>
+                                    {% endif %}
                                     {% render_field form.end_date class="form-control" %}
                                     {% for error in form.end_date.errors %}
                                     <span class="help-block">{{ error }}</span>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "css-loader": "^0.25.0",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
-    "flatpickr": "2.3.4",
+    "flatpickr": "2.6.1",
     "font-awesome": "4.6.3",
     "jquery": "2.2.4",
     "js-cookie": "~2.1.2",


### PR DESCRIPTION
The language/date display switching seems to work now.

Not yet working: 
- showing form field for start and end dates when creating offline phases
- adding a timezone display with the current timezone to the datepicker (or helptext of the form)