### PR TITLE
Use empty_form for adding offline phase

### DIFF
--- a/euth/dashboard/static/add_offline_phase/add_offline_phase.js
+++ b/euth/dashboard/static/add_offline_phase/add_offline_phase.js
@@ -2,8 +2,8 @@
 window.jQuery(document).ready(function () {
   function updateNewElement (element) {
     element.addClass('phaseform-offline-phase')
-    element.find('#id_phases-0-type').val('euth_offlinephases:000:offline')
-    element.find('#id_phases-0-delete').val(0)
+    element.find('#id_phases-__prefix__-type').val('euth_offlinephases:000:offline')
+    element.find('#id_phases-__prefix__-delete').val(0)
     element.find('.collapse').eq(0).text(django.gettext('Offline Phase')).append('<i class="fa fa-chevron-up pull-right"></i>')
     element.find(('[type=text][readonly]')).remove()
     element.css('display', 'block')
@@ -24,23 +24,6 @@ window.jQuery(document).ready(function () {
       element.find('.phasefrom-collapse-top').prepend(button)
       return button
     }
-  }
-
-  function setNewElementInputValues (element) {
-    element.find(':input:not([type=button])').each(function () {
-      var currentType = $(this).attr('name').split('-')[2]
-      if (currentType !== 'type' && currentType !== 'delete') {
-        $(this).val('')
-      }
-      if (currentType === 'start_date' || currentType === 'end_date') {
-        $(this).attr('data-default-date', '')
-        $(this).val('')
-        $(this).flatpickr()
-      }
-      if (currentType === 'id') {
-        $(this).removeAttr('value')
-      }
-    })
   }
 
   function setPhaseIds () {
@@ -65,10 +48,12 @@ window.jQuery(document).ready(function () {
   }
 
   function cloneMore (selector, type, target) {
-    var newElement = $(selector).clone()
+    var newElementSource = $('#phase-form-template').html()
+    var newElement = $(newElementSource)
+    newElement.find('.flatpickr').flatpickr()
     var total = $('#id_' + type + '-TOTAL_FORMS').val()
+
     updateNewElement(newElement)
-    setNewElementInputValues(newElement)
 
     $(target).after(newElement)
     $(target).remove()

--- a/euth/dashboard/templates/euth_dashboard/includes/phase_form.html
+++ b/euth/dashboard/templates/euth_dashboard/includes/phase_form.html
@@ -1,0 +1,83 @@
+{% load i18n widget_tweaks form_tags %}
+
+<div class="phase-form {% if form.instance.type == 'euth_offlinephases:000:offline' %}phaseform-offline-phase{% endif %}" {% if form.delete.value == '1' %}style="display: none;"{% endif %}>
+    <div class="phasefrom-collapse-top">
+        {% if form.instance.type == 'euth_offlinephases:000:offline' %}
+        <button type="button" class="phaseform-delete btn btn-danger"><i class="fa fa-times" aria-hidden="true"></i></button>
+        {% endif %}
+        <h5>
+            <a href="#phase-{{ form.prefix }}" class="collapse collapsed" data-toggle="collapse">
+                {% if form.instance.id %}
+                {{ form.instance.content.name }}
+                {% elif form.type.value %}
+                {% getPhaseName form.type.value as phasename %}
+                {{ phasename }}
+                {% else %}
+                {% trans 'Offlinephase' %}
+                {% endif %}
+                {% if form.errors %}<span class="info-number">{{ form.errors|length }}</span>{% endif %}
+                <i class="fa fa-chevron-up pull-right"></i>
+            </a>
+        </h5>
+    </div>
+    {% for error in form.non_field_errors %}
+    <span class="help-block">{{ error }}</span>
+    {% endfor %}
+
+
+    <div class="single-phase collapse" id="phase-{{ form.prefix }}">
+        {% for field in form.visible_fields %}
+        {% if field != form.start_date and field != form.end_date %}
+        <div class="form-group {% if field.errors %} has-error{% endif %}">
+            <label>
+                {{ field.label }} {% trans 'of Phase '%}: <br />
+                {% if field.help_text %}
+                <p><i>{{ field.help_text }}</i></p>
+                {% endif %}
+            </label>
+            {% render_field field class="form-control" %}
+            {% for error in field.errors %}
+            <span class="help-block">{{ error }}</span>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        {% endfor %}
+        <div class="row">
+            <div class="col-lg-6">
+                <div class="form-group {% if form.start_date.errors %} has-error{% endif %}">
+                    <label>
+                        {{ form.start_date.label }} {% trans 'of Phase '%}:</br>
+                        {% if form.start_date.help_text %}
+                        <i>{{ form.start_date.help_text }}</i><br />
+                        {% endif %}
+                    </label>
+                    {% render_field form.start_date class="form-control" %}
+                    {% for error in form.start_date.errors %}
+                    <span class="help-block">{{ error }}</span>
+                    {% endfor %}
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <div class="form-group {% if form.end_date.errors %} has-error{% endif %}">
+                    <label>
+                        {{ form.end_date.label }} {% trans 'of Phase '%}:<br />
+                        {% if form.end_date.help_text %}
+                        <i>{{ form.end_date.help_text }}</i><br />
+                        {% endif %}
+                    </label>
+                    {% render_field form.end_date class="form-control" %}
+                    {% for error in form.end_date.errors %}
+                    <span class="help-block">{{ error }}</span>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+        {% for hidden in form.hidden_fields %}
+        {{ hidden }}
+        {% endfor %}
+        {% if form.instance.offlinephase %}
+        <a class="update-offline-documentation btn btn-sm btn-dark btn-primary" href="{% url 'offlinephase-edit' form.instance.offlinephase.pk %}">{% trans 'edit documentation' %}</a>
+        {% endif %}
+    </div>
+</div>

--- a/euth/dashboard/templates/euth_dashboard/includes/project_form_participation_tab.html
+++ b/euth/dashboard/templates/euth_dashboard/includes/project_form_participation_tab.html
@@ -27,96 +27,20 @@
             </a>
             {% endif %}
 
-            {% with form.phases as phase_forms %}
+            <script id="phase-form-template" type="text/template">
+            {% include "euth_dashboard/includes/phase_form.html" with form=form.phases.empty_form %}
+            </script>
+
             {% for form in form.phases %}
+            {% include "euth_dashboard/includes/phase_form.html" with form=form %}
+            {% endfor %}
 
-                <div class="phase-form {% if form.instance.type == 'euth_offlinephases:000:offline' %}phaseform-offline-phase{% endif %}" {% if form.delete.value == '1' %}style="display: none;"{% endif %}>
-                    <div class="phasefrom-collapse-top">
-                        {% if form.instance.type == 'euth_offlinephases:000:offline' %}
-                        <button type="button" class="phaseform-delete btn btn-danger"><i class="fa fa-times" aria-hidden="true"></i></button>
-                        {% endif %}
-                        <h5>
-                            <a href="#phase-{{ forloop.counter }}" class="collapse collapsed" data-toggle="collapse">
-                                {% if form.instance.id %}
-                                {{ form.instance.content.name }}
-                                {% else %}
-                                {% getPhaseName form.type.value as phasename %}
-                                {{ phasename }}
-                                {% endif %}
-                                {% if form.errors %}<span class="info-number">{{ form.errors|length }}</span>{% endif %}
-                                <i class="fa fa-chevron-up pull-right"></i>
-                            </a>
-                        </h5>
-                    </div>
-                    {% for error in form.non_field_errors %}
-                    <span class="help-block">{{ error }}</span>
-                    {% endfor %}
-
-
-                    <div class="single-phase collapse" id="phase-{{ forloop.counter }}">
-                    {% for field in form.visible_fields %}
-                        {% if field != form.start_date and field != form.end_date %}
-                        <div class="form-group {% if field.errors %} has-error{% endif %}">
-                            <label>
-                                {{ field.label }} {% trans 'of Phase '%}: <br />
-                                {% if field.help_text %}
-                                <p><i>{{ field.help_text }}</i></p>
-                                {% endif %}
-                            </label>
-                            {% render_field field class="form-control" %}
-                            {% for error in field.errors %}
-                            <span class="help-block">{{ error }}</span>
-                            {% endfor %}
-                        </div>
-                        {% endif %}
-
-                        {% endfor %}
-                        <div class="row">
-                            <div class="col-lg-6">
-                                <div class="form-group {% if form.start_date.errors %} has-error{% endif %}">
-                                    <label>
-                                        {{ form.start_date.label }} {% trans 'of Phase '%}:</br>
-                                        {% if form.start_date.help_text %}
-                                        <i>{{ form.start_date.help_text }}</i><br />
-                                        {% endif %}
-                                    </label>
-                                    {% render_field form.start_date class="form-control" %}
-                                    {% for error in form.start_date.errors %}
-                                    <span class="help-block">{{ error }}</span>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                            <div class="col-lg-6">
-                                <div class="form-group {% if form.end_date.errors %} has-error{% endif %}">
-                                    <label>
-                                        {{ form.end_date.label }} {% trans 'of Phase '%}:<br />
-                                        {% if form.end_date.help_text %}
-                                        <i>{{ form.end_date.help_text }}</i><br />
-                                        {% endif %}
-                                    </label>
-                                    {% render_field form.end_date class="form-control" %}
-                                    {% for error in form.end_date.errors %}
-                                    <span class="help-block">{{ error }}</span>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                        </div>
-                        {% for hidden in form.hidden_fields %}
-                        {{ hidden }}
-                        {% endfor %}
-                        {% if form.instance.offlinephase %}
-                        <a class="update-offline-documentation btn btn-sm btn-dark btn-primary" href="{% url 'offlinephase-edit' form.instance.offlinephase.pk %}">{% trans 'edit documentation' %}</a>
-                        {% endif %}
-                    </div>
-            </div>
-            {% next phase_forms forloop.counter0 as next_element %}
+            {% next form.phases forloop.counter0 as next_element %}
             {% if not form.instance.type == 'euth_offlinephases:000:offline' and not next_element.instance.type == 'euth_offlinephases:000:offline' %}
             <a class="add-offline-phase btn btn-gray btn-primary btn-sm" href="">
                 <i class="fa fa-plus"></i> {% trans 'add offline phase'%}
             </a>
             {% endif %}
-            {% endfor %}
-            {% endwith %}
         </div>
     </div>
 </article>


### PR DESCRIPTION
solves #644

- [x] use formset.emtpy_form to render html for offline form
- [ ] ensure that the form template renders as complete offline form
     - remove post parse modifications from `updateNewElement`
- [ ] use can_order feature of formset to specify to order in the formset
    - remove replace `setPhasesId` with `updateOrder`
- [ ] remove hidden type field since it basically allows the user to modify the project to any sequence of phases that they want
- [ ] NTH: Factor this out into reusable component for each formset
