### PR TITLE
change block.value to block when rendering blocks

### DIFF
--- a/home/templates/home/includes/sf_blocks.html
+++ b/home/templates/home/includes/sf_blocks.html
@@ -4,7 +4,7 @@ xxx
 
                         {% for block in blocks %}
                             {% if block.block_type == 'heading' %}
-                                <h1>{{ block.value }}</h1>
+                                <h1>{{ block }}</h1>
                             {% elif block.block_type == 'image' %}
                                 {% image block.value width-900 class="img-responsive" %}
                             {% else %}

--- a/home/templates/home/manuals_detail_page.html
+++ b/home/templates/home/manuals_detail_page.html
@@ -27,13 +27,13 @@
                         {% if block.block_type == 'image' %}
                              {% image block.value original class="img-responsive" %}
                         {% elif block.block_type == 'heading' %}
-                            <h2>{{ block.value }}</h2>
+                            <h2>{{ block }}</h2>
                         {% else %}
-                            {{ block.value }}
+                            {{ block }}
                         {% endif %}
                     </div>
                     {% else %}
-                        {{ block.value }}
+                        {{ block }}
                     {% endif %}
                 {% endfor %}
                 </section>

--- a/home/templates/home/manuals_index.html
+++ b/home/templates/home/manuals_index.html
@@ -45,15 +45,15 @@
                     {% if block.block_type == 'image' %}
                          {% image block.value original class="img-responsive" %}
                     {% elif block.block_type == 'heading' %}
-                        <h2>{{ block.value }}</h2>
+                        <h2>{{ block }}</h2>
                     {% else %}
-                        {{ block.value }}
+                        {{ block }}
                     {% endif %}
                     </div>
                 </div>
             </div>
             {% else %}
-                {{ block.value }}
+                {{ block }}
             {% endif %}
         {% endfor %}
     </section>

--- a/home/templates/home/simple_page.html
+++ b/home/templates/home/simple_page.html
@@ -5,22 +5,22 @@
 {% include "home/includes/simple_header.html" with image=page.intro_image title=page.translated_title intro=page.translated_intro %}
 <section class="page-body">
 {% for block in self.body %}
-    {% if block.block_type == 'heading' or block.block_type == 'paragraph' or block.block_type == 'rich_text' or block.block_type == 'image' %}
+    {% if block.block_type == 'heading' or block.block_type == 'paragraph' or block.block_type == 'rich_text' or block.block_type == 'image' or block.block_type == 'accordion_block' %}
     <div class="block-inner">
         <div class="container">
             <div class="container-narrow">
             {% if block.block_type == 'image' %}
                  {% image block.value original class="img-responsive" %}
             {% elif block.block_type == 'heading' %}
-                <h2>{{ block.value }}</h2>
+                <h2>{{ block }}</h2>
             {% else %}
-                {{ block.value }}
+                {{ block }}
             {% endif %}
             </div>
         </div>
     </div>
     {% else %}
-        {{ block.value }}
+        {{ block }}
     {% endif %}
 {% endfor %}
 </section>


### PR DESCRIPTION
fixes #1003 

I guess after the automated update of wagtail in https://github.com/liqd/a4-opin/commit/13c35be122eaa4f73c54e62587fb9114a15867fa using block.value for block rendering was not valid anymore (switching back to older version also did not work for some migrations errors, but I also did not try too hard)

@slomo this should be merged with the release2.8 branch and not master, right?