### PR TITLE
remove ManifestStaticFilesStorage from build.py and production.py

### DIFF
--- a/euth_wagtail/settings/build.py
+++ b/euth_wagtail/settings/build.py
@@ -1,5 +1,3 @@
 from .base import *
 
 SECRET_KEY = "dummykeyforbuilding"
-
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'

--- a/euth_wagtail/settings/production.py
+++ b/euth_wagtail/settings/production.py
@@ -14,4 +14,3 @@ INSTALLED_APPS += [
     'allauth.socialaccount.providers.facebook',
     'allauth.socialaccount.providers.google',
 ]
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'


### PR DESCRIPTION
As cache busting does not work in this project, we decided to disable it for now. We will try to use it again, when the django version is updated-