### PR TITLE
 Remove COMPRESS* settings

### DIFF
--- a/euth_wagtail/settings/production.py
+++ b/euth_wagtail/settings/production.py
@@ -1,8 +1,5 @@
 from .base import *
 
-COMPRESS = True
-COMPRESS_OFFLINE = True
-
 DEBUG = False
 
 try:


### PR DESCRIPTION
They are not used anymore, as the django-compressor dependency
has been removed