### PR TITLE
Ka 2019 02 dashboard styling

### DIFF
--- a/euth/ideas/views.py
+++ b/euth/ideas/views.py
@@ -8,8 +8,8 @@ from adhocracy4.filters import views as filter_views
 from adhocracy4.modules.models import Module
 from euth.projects import mixins as prj_mixins
 
-from . import models as idea_models
 from . import forms
+from . import models as idea_models
 from .filters import IdeaFilterSet
 
 

--- a/euth/organisations/templates/euth_organisations/organisation_form.html
+++ b/euth/organisations/templates/euth_organisations/organisation_form.html
@@ -53,5 +53,5 @@
 
     </form>
     </div>
-
+</div>
 {% endblock %}

--- a/euth/organisations/templates/euth_organisations/organisation_form.html
+++ b/euth/organisations/templates/euth_organisations/organisation_form.html
@@ -4,9 +4,9 @@
 {% block title %}{% trans "Settings" %} &mdash; {{ block.super }}{% endblock%}
 
 {% block dashboard_content %}
-<div class="general-form row">
+<div class="general-form dashboard-content row">
     <div class="col-md-8 col-md-offset-2">
-        <h1>{% trans "Edit your organisagtion details" %}</h1>
+        <h1 class="dashboard-content-heading">{% trans "Edit your organisation details" %}</h1>
     <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
         {% csrf_token %}
 

--- a/euth_wagtail/static/scss/components/_dashboard-nav.scss
+++ b/euth_wagtail/static/scss/components/_dashboard-nav.scss
@@ -18,7 +18,6 @@
         border-left: 2px solid $brand-primary;
         color: $brand-primary;
     }
-
 }
 
 .dashboard-left-nav-header {
@@ -28,5 +27,9 @@
     margin: 0;
     padding: 15px 15px 15px 10px;
     border-bottom: 1px solid white;
+}
 
+.dashboard-nav-btn {
+    margin-bottom: 30px;
+    font-size: 16px;
 }

--- a/euth_wagtail/static/scss/components/_dashboard.scss
+++ b/euth_wagtail/static/scss/components/_dashboard.scss
@@ -58,6 +58,24 @@
     margin-top: 40px;
 }
 
+.dashboard-content-header::after {
+    display: block;
+    content: "";
+    clear: both;
+}
+
+.dashboard-content-header {
+    margin-bottom: 40px;
+}
+
+.dashboard-content-left {
+    display: inline-block;
+}
+
+.dashboard-content-right {
+    float: right;
+}
+
 .dashboard-content-heading {
     margin: 0 0 20px 0;
     font-size: 24px;

--- a/euth_wagtail/static/scss/core/_buttons.scss
+++ b/euth_wagtail/static/scss/core/_buttons.scss
@@ -87,7 +87,8 @@ span.btn-dark:focus {
 
     &:hover,
     &:focus {
-        color: $gray-light;
+        color: $list-group-link-hover-color;
+        background-color: $list-group-hover-bg;
     }
 }
 

--- a/euth_wagtail/templates/a4dashboard/base_dashboard_project.html
+++ b/euth_wagtail/templates/a4dashboard/base_dashboard_project.html
@@ -3,7 +3,6 @@
 
 {% block dashboard_content %}
 <div class="dashboard-content">
-    <a href="{% url 'a4dashboard:project-list' organisation_slug=view.organisation.slug %}" class="btn btn-gray dashboard-nav-btn">{% trans 'Back to project overview' %}</a>
     <div class="row">
         <div class="col-md-3 dashboard-left-nav">
             <h2 class="dashboard-left-nav-header">{{ project.name }}</h2>

--- a/euth_wagtail/templates/a4dashboard/base_dashboard_project.html
+++ b/euth_wagtail/templates/a4dashboard/base_dashboard_project.html
@@ -3,7 +3,7 @@
 
 {% block dashboard_content %}
 <div class="dashboard-content">
-    <a href="" class="btn btn-gray dashboard-nav-btn">{% trans 'Back to project overview' %}</a>
+    <a href="{% url 'a4dashboard:project-list' organisation_slug=view.organisation.slug %}" class="btn btn-gray dashboard-nav-btn">{% trans 'Back to project overview' %}</a>
     <div class="row">
         <div class="col-md-3 dashboard-left-nav">
             <h2 class="dashboard-left-nav-header">{{ project.name }}</h2>

--- a/euth_wagtail/templates/a4dashboard/base_dashboard_project.html
+++ b/euth_wagtail/templates/a4dashboard/base_dashboard_project.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 
 {% block dashboard_content %}
-    <div class="row dashboard-content">
+<div class="dashboard-content">
+    <a href="" class="btn btn-gray dashboard-nav-btn">{% trans 'Back to project overview' %}</a>
+    <div class="row">
         <div class="col-md-3 dashboard-left-nav">
             <h2 class="dashboard-left-nav-header">{{ project.name }}</h2>
             <div class="list-group">
@@ -42,4 +44,5 @@
             {% include "a4dashboard/includes/preview.html" with project=project %}
         </div>
     </div>
+</div>
 {% endblock %}

--- a/euth_wagtail/templates/a4dashboard/base_project_list.html
+++ b/euth_wagtail/templates/a4dashboard/base_project_list.html
@@ -8,9 +8,6 @@
         <div class="list-group">
             <a href="{% url 'a4dashboard:project-list' organisation_slug=view.organisation.slug %}" class="list-group-item {% if request.resolver_match.url_name == 'project-list' %}active{% endif %}">{% trans "Projects" %}</a>
         </div>
-        <a href="{% url 'a4dashboard:blueprint-list' organisation_slug=view.organisation.slug %}" class="btn btn-primary btn-wide">
-                {% trans 'New Project' %}
-        </a>
     </div>
     <div class="col-md-9">
         <div class="">

--- a/euth_wagtail/templates/a4dashboard/blueprint_list.html
+++ b/euth_wagtail/templates/a4dashboard/blueprint_list.html
@@ -4,55 +4,59 @@
 {% block title %}{% trans "New Project" %} &mdash; {{ block.super }}{% endblock%}
 
 {% block dashboard_content %}
-<div class="container">
-    <h1>{% trans "What kind of project would you like to create?" %}</h1>
+<div class="container dashboard-content row">
+    <div class="col-md-10 col-md-offset-1">
+        <h1 class="dashboard-content-heading">
+            {% trans "What kind of project would you like to create?" %}
+        </h1>
 
-    <div class="blueprint-list">
+        <div class="blueprint-list">
 
-        <div class="dst-tile">
-            <img src="{% static 'images/placeholder_transparent.png' %}" alt="Decision support tool">
-            <h2 class="sans-serif h4">{% trans 'Not sure which template?' %}</h2>
-            <div class="dst-description">
-                <h3 class="h5">{% trans "Try the Decision Support Tool (DST)!" %}</h3>
-                {% trans "In just three minutes you'll find out which process suits your needs. It's easy." %}
+            <div class="dst-tile">
+                <img src="{% static 'images/placeholder_transparent.png' %}" alt="Decision support tool">
+                <h2 class="sans-serif h4">{% trans 'Not sure which template?' %}</h2>
+                <div class="dst-description">
+                    <h3 class="h5">{% trans "Try the Decision Support Tool (DST)!" %}</h3>
+                    {% trans "In just three minutes you'll find out which process suits your needs. It's easy." %}
+                </div>
+
+                <div class="dst-footer">
+                    <a href="{% url 'blueprints-form' organisation_slug=view.organisation.slug %}"
+                       class="btn btn-primary">
+                        {% trans 'Choose template'%}
+                    </a>
+                </div>
             </div>
 
-            <div class="dst-footer">
-                <a href="{% url 'blueprints-form' organisation_slug=view.organisation.slug %}"
-                   class="btn btn-primary">
-                    {% trans 'Choose template'%}
-                </a>
-            </div>
-        </div>
-
-        {% for blueprint_slug, blueprint in view.blueprints %}
+            {% for blueprint_slug, blueprint in view.blueprints %}
             <div class="blueprint-tile">
-            <img class="blueprint-image" src="{% static blueprint.image %}" alt="{{ blueprint.title }}">
-            <h2 class="sans-serif h4">{{ blueprint.title }}</h2>
-            <div class="blueprint-description">
-                {{ blueprint.description | linebreaks }}
+                <img class="blueprint-image" src="{% static blueprint.image %}" alt="{{ blueprint.title }}">
+                <h2 class="sans-serif h4">{{ blueprint.title }}</h2>
+                <div class="blueprint-description">
+                    {{ blueprint.description | linebreaks }}
+                </div>
+
+                <div class="blueprint-phases">
+                    <ul class="list-unstyled">
+                        {% for phase_content in blueprint.content %}
+                        <li><strong>Phase {{ forloop.counter }}</strong>: {{ phase_content.description }}</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+                <div class="blueprint-footer">
+                    <a href="{% url 'a4dashboard:project-create' organisation_slug=view.organisation.slug blueprint_slug=blueprint_slug %}"
+                       class="btn btn-primary">
+                        {% trans 'use this template' %}
+                    </a>
+
+                    <button class="btn-link" type="button" data-toggle="modal" data-target="#dst-infopage-{{ blueprint_slug }}">{% trans 'Learn More' %}</button>
+                </div>
+
+                {% include 'euth_blueprints/includes/infopage.html'%}
+
             </div>
-
-            <div class="blueprint-phases">
-                <ul class="list-unstyled">
-                    {% for phase_content in blueprint.content %}
-                    <li><strong>Phase {{ forloop.counter }}</strong>: {{ phase_content.description }}</li>
-                    {% endfor %}
-                </ul>
-            </div>
-            <div class="blueprint-footer">
-                <a href="{% url 'a4dashboard:project-create' organisation_slug=view.organisation.slug blueprint_slug=blueprint_slug %}"
-                   class="btn btn-primary">
-                    {% trans 'use this template' %}
-                </a>
-
-                <button class="btn-link" type="button" data-toggle="modal" data-target="#dst-infopage-{{ blueprint_slug }}">{% trans 'Learn More' %}</button>
-            </div>
-
-            {% include 'euth_blueprints/includes/infopage.html'%}
-
+            {% endfor %}
         </div>
-        {% endfor %}
-
+    </div>
 </div>
 {% endblock %}

--- a/euth_wagtail/templates/a4dashboard/includes/project_list_item.html
+++ b/euth_wagtail/templates/a4dashboard/includes/project_list_item.html
@@ -3,38 +3,38 @@
 {% project_tile_image_copyright project as project_image_copyright %}
 
 <li class="dashboard-projects-listitem">
-        <div class="dashboard-projects-image" {% if project_image %}style="background-image: url({% thumbnail project_image '170x170' crop %})"{% endif %}>
-        </div>
-        <div class="dashboard-projects-body">
-            <div class="row dashboard-projects-content">
-                <div class="col-md-4">
-                    <h2 class="dashboard-projects-name">
-                        {{ project.name }}
-                    </h2>
-                    <div class="dashboard-projects-labels">
-                        {% if project.has_finished %}
-                        <span class="label label-finished">{% trans "Finished" %}</span>
-                        {% endif %}
-                        {% if not project.is_public %}
-                        <span class="label label-private">{% trans 'private' %}</span>
-                        {% endif %}
-                    </div>
+    <div class="dashboard-projects-image" {% if project_image %}style="background-image: url({% thumbnail project_image '170x170' crop %})"{% endif %}>
+    </div>
+    <div class="dashboard-projects-body">
+        <div class="row dashboard-projects-content">
+            <div class="col-md-4">
+                <h2 class="dashboard-projects-name">
+                    {{ project.name }}
+                </h2>
+                <div class="dashboard-projects-labels">
+                    {% if project.has_finished %}
+                    <span class="label label-finished">{% trans "Finished" %}</span>
+                    {% endif %}
+                    {% if not project.is_public %}
+                    <span class="label label-private">{% trans 'private' %}</span>
+                    {% endif %}
                 </div>
-                <div class="col-md-8">
-                    <div class="btn-group pull-right dashboard-projects-actions" role="group" aria-label="project actions">
-                        <a href="{% url 'a4dashboard:project-edit' project_slug=project.slug %}" type="button" class="btn btn-gray btn-sm">
-                            <i class="fa fa-eye" aria-hidden="true"></i>
-                            {% if project.is_draft %}
-                            {% trans 'Preview' %}
-                            {% else %}
-                            {% trans 'View' %}
-                            {% endif %}
-                        </a>
-                        <a href="{% url 'a4dashboard:project-edit' project_slug=project.slug %}" type="button" class="btn btn-gray btn-sm">
-                            <i class="fa fa-pencil" aria-hidden="true"></i>
-                            {% trans 'Edit'%}
-                        </a>
-                        <div class="btn-group" role="group">
+            </div>
+            <div class="col-md-8">
+                <div class="btn-group pull-right dashboard-projects-actions" role="group" aria-label="project actions">
+                    <a href="{{ project.get_absolute_url }}" type="button" class="btn btn-gray btn-sm">
+                        <i class="fa fa-eye" aria-hidden="true"></i>
+                        {% if project.is_draft %}
+                        {% trans 'Preview' %}
+                        {% else %}
+                        {% trans 'View' %}
+                        {% endif %}
+                    </a>
+                    <a href="{% url 'a4dashboard:project-edit' project_slug=project.slug %}" type="button" class="btn btn-gray btn-sm">
+                        <i class="fa fa-pencil" aria-hidden="true"></i>
+                        {% trans 'Edit'%}
+                    </a>
+                    <div class="btn-group" role="group">
                         <button type="button" class="btn btn-gray btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                           ...
                         </button>

--- a/euth_wagtail/templates/a4dashboard/project_list.html
+++ b/euth_wagtail/templates/a4dashboard/project_list.html
@@ -4,7 +4,14 @@
 {% block title %}{% trans "Projects" %} &mdash; {{ block.super }}{% endblock%}
 
 {% block project_list %}
-    <h1 class="dashboard-content-heading">{% trans 'Projects' %}</h1>
+    <div class="dashboard-content-header">
+        <h1 class="dashboard-content-left dashboard-content-heading">{% trans 'Projects' %}</h1>
+        <div class="dashboard-content-right">
+            <a href="{% url 'a4dashboard:blueprint-list' organisation_slug=view.organisation.slug %}" class="btn btn-primary">
+                {% trans 'New Project' %}
+            </a>
+        </div>
+    </div>
 
     {% if project_list|length > 0 %}
     <ul class="dashboard-projects-list">


### PR DESCRIPTION
- change heading of orgsnisation settings
- link to project detail view in project list
- move button 'new project'
- make blueprint list narrower and change styling of heading
- hover-styles gray-btn
- add link back to project list (but I am unhappy with what it looks like!)