### PR TITLE
dropdown and popovers: adding js for dropdowns in popover file

### DIFF
--- a/euth/projects/static/euth_projects/timeline-popover.js
+++ b/euth/projects/static/euth_projects/timeline-popover.js
@@ -12,3 +12,5 @@ $('body').on('click', function (e) {
     }
   })
 })
+
+$('.dropdown-toggle').dropdown()

--- a/euth/projects/templates/euth_projects/project_detail.html
+++ b/euth/projects/templates/euth_projects/project_detail.html
@@ -4,7 +4,7 @@
 {% block title %}{{view.project.name}}{% endblock %}
 
 {% block extra_js %}
-<script src="{% static 'euth_projects/timeline_popover.js' %}"></script>
+<script src="{% static 'timeline_popover.js' %}"></script>
 {% endblock %}
 
 {% block extra_messages %}


### PR DESCRIPTION
this stops popover js overwriting dropdown and ensures both work when on same page