### PR TITLE
euth/ideas/templates: Include all existing GET parameters in pagination

### DIFF
--- a/euth/ideas/templates/euth_ideas/includes/pagination.html
+++ b/euth/ideas/templates/euth_ideas/includes/pagination.html
@@ -4,7 +4,8 @@
         <ul class="pagination">
             {% if page_obj.has_previous and page_obj.paginator.num_pages >= 6  %}
             <li class="page-item">
-                <a class="page-link" href="?{% if view.sort %}sort={{view.sort}}&{% endif %}page={{ page_obj.previous_page_number }}#idea-create" aria-label="Previous">
+                {% combined_url_parameter request.GET page=page_obj.previous_page_number as url_par %}
+                <a class="page-link" href="{{ url_par }}#idea-create" aria-label="Previous">
                     <span aria-hidden="true"><i class="fa fa-chevron-left" aria-hidden="true"></i></span>
                 </a>
             </li>
@@ -14,7 +15,8 @@
             {% limited_paginator page_obj as page_range %}
             {% for page in page_range %}
             <li class="page-item {% ifequal page page_obj.number %}active{% endifequal %}">
-                <a class="page-link" href="?{% if view.sort %}sort={{view.sort}}&{% endif %}page={{ page }}#idea-create" aria-label="Next">
+                {% combined_url_parameter request.GET page=page as url_par %}
+                <a class="page-link" href="{{ url_par }}#idea-create" aria-label="Next">
                     {{ page }}
                 </a>
             </li>
@@ -23,7 +25,8 @@
             {% get_range page_obj.number page_obj.paginator.num_pages as range %}
             {% for page in range %}
             <li class="page-item {% ifequal page page_obj.number %}active{% endifequal %}">
-                <a class="page-link" href="?{% if view.sort %}sort={{view.sort}}&{% endif %}page={{ page }}#idea-create">
+                {% combined_url_parameter request.GET page=page as url_par %}
+                <a class="page-link" href="{{ url_par }}#idea-create">
                     {{ page }}
                 </a>
             </li>
@@ -32,7 +35,8 @@
 
             {% if page_obj.has_next and page_obj.paginator.num_pages >= 6 %}
             <li class="page-item">
-                <a class="page-link" href="?{% if view.sort %}sort={{view.sort}}&{% endif %}page={{ page_obj.next_page_number }}#idea-create" aria-label="Next">
+                {% combined_url_parameter request.GET page=page_obj.next_page_number as url_par %}
+                <a class="page-link" href="{{ url_par }}#idea-create" aria-label="Next">
                     <span aria-hidden="true"><i class="fa fa-chevron-right" aria-hidden="true"></i></span>
                 </a>
             </li>

--- a/euth/ideas/templatetags/idea_tags.py
+++ b/euth/ideas/templatetags/idea_tags.py
@@ -18,3 +18,12 @@ def get_range(number, listcount):
 @register.simple_tag
 def is_idea_list(module):
     return Idea.objects.filter(module=module).count() > 0
+
+
+@register.simple_tag
+def combined_url_parameter(request_query_dict, **kwargs):
+    combined_query_dict = request_query_dict.copy()
+    for key in kwargs:
+        combined_query_dict.setlist(key, [kwargs[key]])
+    encoded_parameter = '?' + combined_query_dict.urlencode()
+    return encoded_parameter

--- a/tests/ideas/test_templatetags.py
+++ b/tests/ideas/test_templatetags.py
@@ -1,0 +1,42 @@
+import pytest
+
+from adhocracy4.test import helpers
+
+
+@pytest.mark.django_db
+def test_get_range(rf):
+    request = rf.get('/')
+    template = ('{% load idea_tags %}'
+                '{% get_range page_number_1 page_num_pages as range_1 %}'
+                '{% get_range page_number_5 page_num_pages as range_5 %}'
+                '{% get_range page_number_11 page_num_pages as range_11 %}'
+                '{{ range_1 }}'
+                '{{ range_5 }}'
+                '{{ range_11 }}')
+    context = {'request': request,
+               'page_number_1': 1,
+               'page_number_5': 5,
+               'page_number_11': 11,
+               'page_num_pages': 12}
+    helpers.render_template(template, context)
+
+    assert range(1, 6) == context['range_1']
+    assert range(3, 8) == context['range_5']
+    assert range(8, 13) == context['range_11']
+
+
+@pytest.mark.django_db
+def test_combined_url_parameter(rf):
+    request = rf.get('/?bla=bums&da=dings')
+    template = ('{% load idea_tags %}'
+                '{% combined_url_parameter request.GET as url_par_1 %}'
+                '{% combined_url_parameter request.GET bla="" as url_par_2 %}'
+                '{{ url_par_1 }}'
+                '{{ url_par_2 }}')
+    context = {'request': request}
+    helpers.render_template(template, context)
+
+    assert 'bla=bums' in context['url_par_1']
+    assert 'da=dings' in context['url_par_1']
+    assert 'bla=' in context['url_par_2']
+    assert 'da=dings' in context['url_par_2']


### PR DESCRIPTION
This makes sure we e.g. keep the selected ordering scheme. Copied from A+.

Fixes #1406

---

Can be tested on https://opin-dev.liqd.net/en/projects/paging-test/