### PR TITLE
makefile/settings: adapt test targets to other projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ background:
 
 .PHONY: test
 test:
-	$(VIRTUAL_ENV)/bin/py.test --reuse-db --no-migrations
+	$(VIRTUAL_ENV)/bin/py.test --reuse-db
 
 .PHONY: test-lastfailed
 test-lastfailed:
@@ -73,7 +73,6 @@ test-lastfailed:
 .PHONY: test-clean
 test-clean:
 	if [ -f test_db.sqlite3 ]; then rm test_db.sqlite3; fi
-	find media -iname 'example_*.jpg' -exec rm {} \+
 	$(VIRTUAL_ENV)/bin/py.test
 
 .PHONY: coverage


### PR DESCRIPTION
@Rineee 
So, the migrations problem was that the migrations were not run in a normal test, which kind of makes sense to run test-clean every time there where migrations. But as we handle that differently in all other projects, I also changed it here.
And the test-clean target was probably just broken because it coudln't find the image.
Now it still takes veeery long to run the tests, but they are not failing and can be run with py.test as well (which also takes forever). :tada: 