### PR TITLE
WIP fileupload_formset: add autocomplete to managment form to deal with firfox caching - not working?

### DIFF
--- a/euth/communitydebate/static/js/fileupload_formset.js
+++ b/euth/communitydebate/static/js/fileupload_formset.js
@@ -43,4 +43,8 @@ import { showFileName } from '../../../../euth_wagtail/assets/js/euth_wagtail';
       new DynamicFormSet($formsets.eq(i))
     )
   })
+
+  $(document).ready(function () {
+    document.getElementById('id_topicfileupload_set-TOTAL_FORMS').setAttribute('autocomplete', 'off')
+  })
 })


### PR DESCRIPTION
Not working i think due to autocomplete needing to be on type hidden, but I also added that and it still didn't work so I am at a bit of a loss on that end 
But when I have more time, I want to try to add a function to add value attribute that recounts the filled out forms but should work on something else for a little
in reference to this issue #1916