### PR TITLE
deps/python: add package needed by django-autoslug for cyrillic fields

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,7 @@ feedparser==5.2.1
 micawber==0.5.1
 pyuca==1.2
 raven==6.10.0
+Unidecode==1.1.1 # needed by django-autoslug for cyrillic fields
 wagtail==2.7.3 # pyup: <2.8
 whitenoise==5.1.0
 


### PR DESCRIPTION
I think this should fix this error by django-autoslug:
`AssertionErrorautoslug.fields in pre_save
errorslug is defined before trying to ensure uniqueness`
Sentry: https://sentry.liqd.net/sentry/opin-prod/issues/1047/
Solution: https://stackoverflow.com/questions/40919070/django-autoslug-error-slug-is-defined-before-trying-to-ensure-uniqueness