### PR TITLE
deps: update a4 and adapt py code to access enum

### DIFF
--- a/euth/contrib/sitemaps/adhocracy4_sitemap.py
+++ b/euth/contrib/sitemaps/adhocracy4_sitemap.py
@@ -1,5 +1,6 @@
 from django.contrib.sitemaps import Sitemap
 
+from adhocracy4.projects.enums import Access
 from adhocracy4.projects.models import Project
 
 
@@ -8,4 +9,4 @@ class Adhocracy4Sitemap(Sitemap):
     priority = 0.8
 
     def items(self):
-        return Project.objects.filter(is_draft=False, is_public=True)
+        return Project.objects.filter(is_draft=False, access=Access.PUBLIC)

--- a/euth/projects/templates/euth_projects/includes/project_hero_unit.html
+++ b/euth/projects/templates/euth_projects/includes/project_hero_unit.html
@@ -9,7 +9,7 @@
 
                 {% get_days project.days_left as days %}
                 <p>
-                    {% if not project.is_public %}
+                    {% if project.is_private %}
                     <span class="badge badge-private">{% trans 'private' %}</span>
                     {% endif %}
                     {% if project.is_archived %}

--- a/euth/projects/templatetags/project_class_tags.py
+++ b/euth/projects/templatetags/project_class_tags.py
@@ -1,5 +1,7 @@
 from django import template
 
+from adhocracy4.projects.enums import Access
+
 register = template.Library()
 
 
@@ -7,7 +9,7 @@ register = template.Library()
 def get_class(project):
     if project.is_archived:
         return 'archived'
-    elif not project.is_public:
+    elif project.access == Access.PRIVATE:
         return 'private'
     elif project.has_finished:
         return 'finished'

--- a/euth_wagtail/templates/a4dashboard/includes/project_basic_form.html
+++ b/euth_wagtail/templates/a4dashboard/includes/project_basic_form.html
@@ -4,7 +4,7 @@
 
 {% include 'a4dashboard/includes/form_field.html' with field=form.description %}
 
-{% include 'a4dashboard/includes/form_field.html' with field=form.is_public %}
+{% include 'a4dashboard/includes/form_field.html' with field=form.access %}
 
 {% if project.has_finished %}
     {% include 'a4forms/includes/form_checkbox_field.html' with field=form.is_archived %}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@babel/preset-react": "7.12.1",
     "@babel/runtime": "7.12.1",
     "@fortawesome/fontawesome-free": "5.15.1",
-    "adhocracy4": "github:liqd/adhocracy4#opin-v3.10.3",
+    "adhocracy4": "github:liqd/adhocracy4#ced1aa4db1bf993a9db82a133c1a3ac1b64acbd1",
     "axios": "0.20.0",
     "babel-loader": "8.1.0",
     "bootstrap": "4.5.3",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@opin-v3.10.3#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@ced1aa4db1bf993a9db82a133c1a3ac1b64acbd1#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0
@@ -23,6 +23,7 @@ django-allauth==0.44.0
 django-autoslug==1.9.8
 django-background-tasks==1.2.5
 django-ckeditor==6.0.0
+django-enumfield==2.0.2
 django-filter==2.4.0
 django-multiselectfield==0.1.12
 django-widget-tweaks==1.4.8

--- a/tests/apps/fakeprojects/models.py
+++ b/tests/apps/fakeprojects/models.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.db import models
 
+from adhocracy4.projects.enums import Access
+
 
 class FakeProject():
     """
@@ -8,7 +10,7 @@ class FakeProject():
     """
     name = 'fake projects name'
     active_phase = None
-    is_public = False
+    access = Access.PRIVATE
 
     def has_member(self, user):
         return True

--- a/tests/communitydebate/test_communitydebate_views.py
+++ b/tests/communitydebate/test_communitydebate_views.py
@@ -2,6 +2,7 @@ import pytest
 from django.urls import reverse
 from freezegun import freeze_time
 
+from adhocracy4.projects.enums import Access
 from euth.communitydebate import models
 from euth.communitydebate import phases
 from euth.communitydebate import views
@@ -44,10 +45,8 @@ def test_detail_view(client, topic, topic_file_upload_factory):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('topic__module__project__is_public',
-                          [False])
 def test_detail_view_private(client, topic, user):
-    topic.module.project.is_public = False
+    topic.module.project.access = Access.PRIVATE
     topic.module.project.save()
     url = reverse('topic-detail', kwargs={'slug': topic.slug})
     response = client.get(url)

--- a/tests/dashboard/test_dashboard_views.py
+++ b/tests/dashboard/test_dashboard_views.py
@@ -4,6 +4,7 @@ from django.core import mail
 from django.urls import reverse
 from parler.utils.context import switch_language
 
+from adhocracy4.projects.enums import Access
 from adhocracy4.projects.models import Project
 from tests.helpers import redirect_target
 
@@ -83,7 +84,8 @@ def test_initiator_edit_project(client, phase):
 
     client.post(url, {
         'name': 'Project name',
-        'description': 'Project info'
+        'description': 'Project info',
+        'access': Access.PUBLIC.value
     })
 
     project = Project.objects.get(id=project.id)

--- a/tests/documents/test_document_views.py
+++ b/tests/documents/test_document_views.py
@@ -2,6 +2,7 @@ import pytest
 from django.urls import reverse
 
 from adhocracy4.comments.models import Comment
+from adhocracy4.projects.enums import Access
 from euth.exports import mixins
 from tests.helpers import redirect_target
 
@@ -18,7 +19,8 @@ def test_paragraph_detail_view(client, paragraph):
 
 @pytest.mark.django_db
 def test_paragraph_private_detail_view(client, paragraph_factory, user):
-    paragraph = paragraph_factory(document__module__project__is_public=False)
+    paragraph = paragraph_factory(
+        document__module__project__access=Access.PRIVATE)
 
     url = reverse('paragraph-detail', kwargs={
         'pk': paragraph.pk

--- a/tests/ideas/test_idea_views.py
+++ b/tests/ideas/test_idea_views.py
@@ -2,6 +2,7 @@ import pytest
 from django.urls import reverse
 from freezegun import freeze_time
 
+from adhocracy4.projects.enums import Access
 from euth.ideas import models
 from euth.ideas import phases
 from euth.ideas import views
@@ -36,10 +37,8 @@ def test_detail_view(client, phase, idea):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrized('idea__module__project__is_public',
-                          [False])
 def test_detail_view_private(client, idea, user):
-    idea.module.project.is_public = False
+    idea.module.project.access = Access.PRIVATE
     idea.module.project.save()
     url = reverse('idea-detail', kwargs={'slug': idea.slug})
     response = client.get(url)

--- a/tests/memberships/test_memberships_views.py
+++ b/tests/memberships/test_memberships_views.py
@@ -2,14 +2,16 @@ import pytest
 from django.core import mail
 from django.urls import reverse
 
+from adhocracy4.projects.enums import Access
 from euth.memberships import models
 from tests.helpers import redirect_target
 from tests.helpers import templates_used
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('project__is_public', [False])
 def test_detail_private_project(client, project, user):
+    project.access = Access.PRIVATE
+    project.save()
     project_url = reverse('project-detail', args=[project.slug])
     response = client.get(project_url)
     assert response.status_code == 302
@@ -56,9 +58,10 @@ def test_detail_draft_project(client, project, user):
     assert response.context_data['view'].project == project
 
 
-@pytest.mark.parametrize('project__is_public', [False])
 @pytest.mark.django_db
 def test_create_request(client, project, user):
+    project.access = Access.PRIVATE
+    project.save()
     url = reverse('memberships-request', kwargs={'project_slug': project.slug})
     response = client.get(url)
     assert redirect_target(response) == 'account_login'


### PR DESCRIPTION
The first commit only fixes the py code in so far that the tests succeed and the views are alright. 
But we still need to think about what to do with the access enum. If we need to use all three, we also need to make sure the semipublic makes sense for the projects. And I think as the enum can't be overwritten, we have to use all three (or finally change from enum to choices, which is too late now).
Also, the js code is currently broken. :grimacing: 