### PR TITLE
Ks 2021 04 make semi public projects work

### DIFF
--- a/euth/memberships/dashboard.py
+++ b/euth/memberships/dashboard.py
@@ -13,7 +13,7 @@ class MembershipRequestComponent(DashboardComponent):
     label = _('Members')
 
     def is_effective(self, project_or_module):
-        return project_or_module.is_private
+        return project_or_module.is_private or project_or_module.is_semipublic
 
     def get_base_url(self, project):
         return reverse('a4dashboard:members', kwargs={
@@ -34,7 +34,7 @@ class MembershipInvitesComponent(DashboardComponent):
     label = _('Invited Members')
 
     def is_effective(self, project_or_module):
-        return project_or_module.is_private
+        return project_or_module.is_private or project_or_module.is_semipublic
 
     def get_base_url(self, project):
         return reverse('a4dashboard:invites', kwargs={

--- a/euth/memberships/templates/euth_memberships/emails/invite.en.email
+++ b/euth/memberships/templates/euth_memberships/emails/invite.en.email
@@ -9,7 +9,7 @@ You are invited to join the project “{{ invite.project.name }}” on <i>{{ sit
 {% endblock  %}
 
 {% block content %}
-You were invited as a member of this private project by the user <i>{{ invite.creator.username }}</i>. Private projects allow participants to discuss and decide on topics in an invite-only group of people.  If you want to join the project, please visit the project by clicking the {% if part_type == "txt" %}link{% else %}button{% endif %} below.
+{% if invite.project.is_semipublic %}You were invited as a member of this semi-public project by the user <i>{{ invite.creator.username }}</i>. Semi-public projects are visible for all users, but only participants are allowed to discuss and decide on topics in an invite-only group of people.  {% else %}You were invited as a member of this private project by the user <i>{{ invite.creator.username }}</i>. Private projects allow participants to discuss and decide on topics in an invite-only group of people. {% endif %}If you want to join the project, please visit the project by clicking the {% if part_type == "txt" %}link{% else %}button{% endif %} below.
 {% endblock %}
 
 {% block cta_url %}{{ email.get_host }}{{ invite.get_absolute_url }}{% endblock %}

--- a/euth/projects/apps.py
+++ b/euth/projects/apps.py
@@ -6,4 +6,6 @@ class Config(AppConfig):
     label = 'euth_projects'
 
     def ready(self):
-        import euth.projects.signals  # noqa
+        from . import overwrites
+        from . import signals  # noqa
+        overwrites.overwrite_access_enum_label()

--- a/euth/projects/overwrites.py
+++ b/euth/projects/overwrites.py
@@ -1,0 +1,14 @@
+from django.utils.translation import ugettext_lazy as _
+
+from adhocracy4.projects.enums import Access
+
+
+def overwrite_access_enum_label():
+    Access.__labels__ = {
+        Access.PRIVATE: _('Only invited users can see content and can '
+                          'participate (private).'),
+        Access.PUBLIC: _('All users can see content and can participate '
+                         '(public).'),
+        Access.SEMIPUBLIC: _('All users can see content, only invited users '
+                             'can participate (semi-public).')
+    }

--- a/euth/projects/templates/euth_projects/includes/project_hero_unit.html
+++ b/euth/projects/templates/euth_projects/includes/project_hero_unit.html
@@ -11,6 +11,8 @@
                 <p>
                     {% if project.is_private %}
                     <span class="badge badge-private">{% trans 'private' %}</span>
+                    {% elif project.is_semipublic %}
+                    <span class="badge badge-private">{% trans 'semi-public' %}</span>
                     {% endif %}
                     {% if project.is_archived %}
                     <span class="badge badge-archived">{% trans 'archived' %}</span>

--- a/euth/projects/templates/euth_projects/includes/project_list_item.html
+++ b/euth/projects/templates/euth_projects/includes/project_list_item.html
@@ -5,8 +5,10 @@
     <div class="teaserlist-body">
         {% get_days project.days_left as days %}
         <p>
-            {% if not project.is_public %}
+            {% if project.is_private %}
                 <span class="badge badge-private">{% trans 'private' %}</span>
+            {% elif project.is_semipublic %}
+                <span class="badge badge-private">{% trans 'semi-public' %}</span>
             {% endif %}
             {% if project.has_finished %}
                 <span class="badge badge-finished">{% trans 'finished' %}</span>

--- a/euth/projects/templates/euth_projects/includes/project_tile.html
+++ b/euth/projects/templates/euth_projects/includes/project_tile.html
@@ -9,8 +9,10 @@
         {% get_days project.days_left as days %}
         {% if project.is_archived %}
         <p class="badge badge-archived">{% trans 'archived' %}</p>
-        {% elif not project.is_public %}
+        {% elif project.is_private %}
         <p class="badge badge-private">{% trans 'private' %}</p>
+        {% elif project.is_semipublic %}
+        <p class="badge badge-private">{% trans 'semi-public' %}</p>
         {% elif project.has_finished %}
         <p class="badge badge-finished">{% trans 'finished' %}</p>
         {% elif days %}

--- a/euth/projects/templates/euth_projects/project_detail.html
+++ b/euth/projects/templates/euth_projects/project_detail.html
@@ -178,6 +178,20 @@
             {% endif %}
             {% endif %}
 
+            {% if view.project.is_private %}
+            <div class="container-narrow">
+                <p style="font-size: 0.8rem; text-align: justify">
+                    <i class="fas fa-lock pr-2" aria-hidden="true"></i>{% trans 'This project is not publicly visible. Only invited users can see content and actively participate.' %}
+                </p>
+            </div>
+
+            {% elif view.project.is_semipublic %}
+            <div class="container-narrow">
+                <p style="font-size: 0.8rem; text-align: justify">
+                    <i class="fas fa-eye pr-2" aria-hidden="true"></i>{% trans 'This project is publicly visible. Invited users can actively participate.' %}
+                </p>
+            </div>
+            {% endif %}
 
             {% block phase_content %}{% endblock %}
         </div>

--- a/euth_wagtail/assets/scss/components/_forms.scss
+++ b/euth_wagtail/assets/scss/components/_forms.scss
@@ -7,3 +7,4 @@
 @import "forms/form-section";
 @import "forms/poll-radio";
 @import "forms/questionform";
+@import "forms/widget-radioselect";

--- a/euth_wagtail/assets/scss/components/forms/_widget-radioselect.scss
+++ b/euth_wagtail/assets/scss/components/forms/_widget-radioselect.scss
@@ -1,0 +1,21 @@
+.widget-radioselect {
+    ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    li {
+        margin-left: 1.25em;
+    }
+
+    input {
+        margin-left: -1.25em;
+    }
+
+    label {
+        @extend .form-check__label;
+        height: auto;
+        font-weight: normal;
+    }
+}

--- a/euth_wagtail/templates/a4dashboard/includes/project_list_item.html
+++ b/euth_wagtail/templates/a4dashboard/includes/project_list_item.html
@@ -16,8 +16,10 @@
                     {% if project.has_finished %}
                     <span class="badge badge-finished">{% trans "Finished" %}</span>
                     {% endif %}
-                    {% if not project.is_public %}
+                    {% if project.is_private %}
                     <span class="badge badge-private">{% trans 'private' %}</span>
+                    {% elif project.is_semipublic %}
+                    <span class="badge badge-private">{% trans 'semi-public' %}</span>
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
I wanted to add some styling for the radio buttons of the choices of project access in basic settings of project, but didnt succeed..

I wanted to add something like:
`.widget-radioselect {
    ul {
        list-style: none;
        margin: 0;
        padding: 0;
    }
}
`
but didnt really know where to put it, so its used.. can you help me with that @fuzzylogic2000 or @khamui ?

Also, the helptext for access is now gone, because we removed it in A4, but I guess it is alright, because the choices are self-explanatory?

Open question: probably people should also be able to apply for membership in semi-public projects, right? Maybe we can discuss where to put that tomorrow @fuzzylogic2000 ?