### PR TITLE
deps/python: update wagtail to 2.11 lts

### DIFF
--- a/euth_wagtail/settings/base.py
+++ b/euth_wagtail/settings/base.py
@@ -116,7 +116,6 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'euth.contrib.middleware.TimezoneMiddleware',
     'django.middleware.locale.LocaleMiddleware',
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 ]
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ micawber==0.5.3
 pyuca==1.2
 raven==6.10.0
 Unidecode==1.2.0 # needed by django-autoslug for cyrillic fields
-wagtail==2.7.4 # pyup: <2.8
+wagtail==2.11.8 # pyup: <2.12
 whitenoise==5.2.0
 
 # Inherited a4-core requirements


### PR DESCRIPTION
This wasn't too bad. And it is fine on a fresh DB.
But I did not have a lot of wagtail in my local not-fresh DB. Could you also test it on yours @phillimorland @Rineee ? I will also add more wagtail to my unupdated DB and check it out more thoroughly after lunch.