### PR TITLE
general styles: setting all opin anchor elements '<a>' to not underlined

### DIFF
--- a/euth_wagtail/assets/scss/core/_type.scss
+++ b/euth_wagtail/assets/scss/core/_type.scss
@@ -13,6 +13,7 @@ html {
 
 a {
     transition: color 0.2s;
+    text-decoration: none;
 }
 
 strong {


### PR DESCRIPTION
closes #2316 

think setting all `<a>`-elements to no underline is better. 