### PR TITLE
embeds: using bs5 classes for embeds

### DIFF
--- a/euth_wagtail/templates/micawber/video.html
+++ b/euth_wagtail/templates/micawber/video.html
@@ -1,3 +1,3 @@
-<div class="embed-responsive embed-responsive-16by9">
+<div class="ratio ratio-16x9">
 {{ response.html|safe }}
 </div>

--- a/home/templates/home/blocks/video_block.html
+++ b/home/templates/home/blocks/video_block.html
@@ -1,7 +1,7 @@
 {% load i18n wagtailimages_tags wagtailembeds_tags %}
 <section class="video-block block">
     <h3 class="block-title">{{ self.title }}</h3>
-    <div class="embed-responsive embed-responsive-16by9">
+    <div class="ratio ratio-16x9">
         {% embed self.video.url "500" %}
     </div>
 </section>


### PR DESCRIPTION
close #2340 

@hello-kathi I couldn't check the issue on Prod ("not showing yt videos at all"). Because I am not an admin there.

This PR just fixes the sizing of the embedded videos.