### PR TITLE
Ks 2022 02 update to django 3

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -2,7 +2,7 @@
 
 ## Languages
 
-  - source code uses en_GB (arguments to ugettext == msg_id )
+  - source code uses en_GB (arguments to gettext == msg_id )
      - lower case (except for first word of title or sentence)
   - support many languages with transifex (en, de, it, fr,
     sv, sl, da, el, ka, mk as of 10/2017)

--- a/euth/accounts/forms.py
+++ b/euth/accounts/forms.py
@@ -2,7 +2,7 @@ import collections
 from datetime import date
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from euth.contrib import widgets
 from euth.users.models import User

--- a/euth/accounts/urls.py
+++ b/euth/accounts/urls.py
@@ -1,21 +1,21 @@
-from django.conf.urls import include
-from django.conf.urls import url
+from django.urls import include
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
-    url(
-        r'^$',
+    path(
+        '',
         views.dashboard_default,
         name='account'),
-    url(
-        r'^profile/$',
+    path(
+        'profile/',
         views.AccountProfileView.as_view(),
         name='account-profile'),
-    url(
-        r'^social/',
+    path(
+        'social/',
         include('allauth.socialaccount.urls')),
-    url(
-        r'',
+    path(
+        '',
         include('allauth.account.urls')),
 ]

--- a/euth/accounts/views.py
+++ b/euth/accounts/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth import mixins
 from django.contrib.messages.views import SuccessMessageMixin
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views import generic
 
 from euth.users import models as user_models

--- a/euth/blueprints/blueprints.py
+++ b/euth/blueprints/blueprints.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from enum import Enum
 from enum import unique
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.polls import phases as poll_phases
 from euth.communitydebate import phases as communitydebate_phases

--- a/euth/blueprints/forms.py
+++ b/euth/blueprints/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import blueprints
 

--- a/euth/blueprints/urls.py
+++ b/euth/blueprints/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(r'^(?P<organisation_slug>[-\w_]+)/$',
-        views.SuggestFormView.as_view(), name='blueprints-form'),
+    re_path(r'^(?P<organisation_slug>[-\w_]+)/$',
+            views.SuggestFormView.as_view(), name='blueprints-form'),
 ]

--- a/euth/communitydebate/filters.py
+++ b/euth/communitydebate/filters.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.categories import filters as cat_filters
 from adhocracy4.filters import widgets

--- a/euth/communitydebate/phases.py
+++ b/euth/communitydebate/phases.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4 import phases
 

--- a/euth/communitydebate/urls.py
+++ b/euth/communitydebate/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(r'create/module/(?P<slug>[-\w_]+)/$',
-        views.TopicCreateView.as_view(), name='topic-create'),
-    url(r'^(?P<slug>[-\w_]+)/edit/$',
-        views.TopicUpdateView.as_view(), name='topic-update'),
-    url(r'^(?P<slug>[-\w_]+)/delete/$',
-        views.TopicDeleteView.as_view(), name='topic-delete'),
-    url(r'^(?P<slug>[-\w_]+)/$',
-        views.TopicDetailView.as_view(), name='topic-detail'),
+    re_path(r'create/module/(?P<slug>[-\w_]+)/$',
+            views.TopicCreateView.as_view(), name='topic-create'),
+    re_path(r'^(?P<slug>[-\w_]+)/edit/$',
+            views.TopicUpdateView.as_view(), name='topic-update'),
+    re_path(r'^(?P<slug>[-\w_]+)/delete/$',
+            views.TopicDeleteView.as_view(), name='topic-delete'),
+    re_path(r'^(?P<slug>[-\w_]+)/$',
+            views.TopicDetailView.as_view(), name='topic-detail'),
 ]

--- a/euth/communitydebate/views.py
+++ b/euth/communitydebate/views.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views import generic
 from rules.contrib.views import PermissionRequiredMixin
 

--- a/euth/contrib/filters.py
+++ b/euth/contrib/filters.py
@@ -1,6 +1,6 @@
 import django_filters
 import pyuca
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_countries import Countries
 
 from adhocracy4.filters import filters

--- a/euth/contrib/mixins.py
+++ b/euth/contrib/mixins.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 RIGHT_OF_USE_LABEL = _('I hereby confirm that the copyrights for this '
                        'photo are with me or that I have received '

--- a/euth/contrib/validators.py
+++ b/euth/contrib/validators.py
@@ -1,7 +1,7 @@
 import magic
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def validate_file_type_and_size(upload):

--- a/euth/contrib/widgets.py
+++ b/euth/contrib/widgets.py
@@ -5,7 +5,7 @@ from django.template import loader
 from django.utils import formats
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 
 
 class DateInput(widgets.DateInput):
@@ -57,7 +57,7 @@ class FileUploadWidget(widgets.ClearableFileInput):
         has_file_set = self.is_initial(value)
         is_required = self.is_required
 
-        file_placeholder = ugettext('Select a file from your local folder.')
+        file_placeholder = gettext('Select a file from your local folder.')
         file_input = super().render(name, None, {
             'id': name,
             'class': 'form-control form-control-file'

--- a/euth/dashboard/forms.py
+++ b/euth/dashboard/forms.py
@@ -3,7 +3,7 @@ import parler
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from euth.organisations.models import Organisation
 

--- a/euth/dashboard/urls.py
+++ b/euth/dashboard/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from adhocracy4.dashboard.urls import urlpatterns as a4dashboard_urlpatterns
 from euth.organisations.views import DashboardOrganisationUpdateView
@@ -6,7 +6,7 @@ from euth.organisations.views import DashboardOrganisationUpdateView
 app_name = 'a4dashboard'
 
 urlpatterns = [
-    url(r'^organisations/(?P<organisation_slug>[-\w_]+)/settings/$',
-        DashboardOrganisationUpdateView.as_view(),
-        name='organisation-edit')
+    re_path(r'^organisations/(?P<organisation_slug>[-\w_]+)/settings/$',
+            DashboardOrganisationUpdateView.as_view(),
+            name='organisation-edit')
 ] + a4dashboard_urlpatterns

--- a/euth/documents/exports.py
+++ b/euth/documents/exports.py
@@ -1,5 +1,5 @@
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.comments.models import Comment
 from adhocracy4.exports import mixins as export_mixins

--- a/euth/documents/phases.py
+++ b/euth/documents/phases.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4 import phases
 

--- a/euth/documents/urls.py
+++ b/euth/documents/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
-    url(r'^(?P<pk>\d+)/$', views.ParagraphDetailView.as_view(),
-        name='paragraph-detail'),
+    path('<int:pk>/', views.ParagraphDetailView.as_view(),
+         name='paragraph-detail'),
 ]

--- a/euth/documents/validators.py
+++ b/euth/documents/validators.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 def single_document_per_module(module, pk=None):

--- a/euth/exports/dashboard.py
+++ b/euth/exports/dashboard.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.dashboard import DashboardComponent
 from adhocracy4.dashboard import components

--- a/euth/exports/mixins.py
+++ b/euth/exports/mixins.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ObjectDoesNotExist
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from adhocracy4.exports.views import VirtualFieldMixin
 

--- a/euth/ideas/exports.py
+++ b/euth/ideas/exports.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.exports import mixins as a4_export_mixins
 from adhocracy4.exports import views as a4_export_views

--- a/euth/ideas/filters.py
+++ b/euth/ideas/filters.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.categories import filters as cat_filters
 from adhocracy4.filters import widgets

--- a/euth/ideas/models.py
+++ b/euth/ideas/models.py
@@ -3,7 +3,7 @@ from ckeditor.fields import RichTextField
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4 import transforms
 from adhocracy4.categories.fields import CategoryField

--- a/euth/ideas/phases.py
+++ b/euth/ideas/phases.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4 import phases
 

--- a/euth/ideas/urls.py
+++ b/euth/ideas/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(r'create/module/(?P<slug>[-\w_]+)/$',
-        views.IdeaCreateView.as_view(), name='idea-create'),
-    url(r'^(?P<slug>[-\w_]+)/edit/$',
-        views.IdeaUpdateView.as_view(), name='idea-update'),
-    url(r'^(?P<slug>[-\w_]+)/delete/$',
-        views.IdeaDeleteView.as_view(), name='idea-delete'),
-    url(r'^(?P<slug>[-\w_]+)/$',
-        views.IdeaDetailView.as_view(), name='idea-detail'),
+    re_path(r'create/module/(?P<slug>[-\w_]+)/$',
+            views.IdeaCreateView.as_view(), name='idea-create'),
+    re_path(r'^(?P<slug>[-\w_]+)/edit/$',
+            views.IdeaUpdateView.as_view(), name='idea-update'),
+    re_path(r'^(?P<slug>[-\w_]+)/delete/$',
+            views.IdeaDeleteView.as_view(), name='idea-delete'),
+    re_path(r'^(?P<slug>[-\w_]+)/$',
+            views.IdeaDetailView.as_view(), name='idea-detail'),
 ]

--- a/euth/ideas/views.py
+++ b/euth/ideas/views.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views import generic
 from rules.contrib.views import PermissionRequiredMixin
 

--- a/euth/maps/exports.py
+++ b/euth/maps/exports.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.exports import mixins as a4_export_mixins
 from adhocracy4.exports import views as a4_export_views

--- a/euth/maps/forms.py
+++ b/euth/maps/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from adhocracy4.categories import forms as category_forms
 from adhocracy4.maps import widgets

--- a/euth/maps/models.py
+++ b/euth/maps/models.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.maps import fields as map_fields
 from euth.ideas import models as idea_models

--- a/euth/maps/phases.py
+++ b/euth/maps/phases.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4 import phases
 

--- a/euth/maps/urls.py
+++ b/euth/maps/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(r'create/module/(?P<slug>[-\w_]+)/$',
-        views.MapIdeaCreateView.as_view(), name='map-idea-create'),
-    url(r'^(?P<slug>[-\w_]+)/edit/$',
-        views.MapIdeaUpdateView.as_view(), name='map-idea-update'),
-    url(r'^(?P<slug>[-\w_]+)/delete/$',
-        views.MapIdeaDeleteView.as_view(), name='map-idea-delete'),
-    url(r'^(?P<slug>[-\w_]+)/$',
-        views.MapIdeaDetailView.as_view(), name='map-idea-detail'),
+    re_path(r'create/module/(?P<slug>[-\w_]+)/$',
+            views.MapIdeaCreateView.as_view(), name='map-idea-create'),
+    re_path(r'^(?P<slug>[-\w_]+)/edit/$',
+            views.MapIdeaUpdateView.as_view(), name='map-idea-update'),
+    re_path(r'^(?P<slug>[-\w_]+)/delete/$',
+            views.MapIdeaDeleteView.as_view(), name='map-idea-delete'),
+    re_path(r'^(?P<slug>[-\w_]+)/$',
+            views.MapIdeaDetailView.as_view(), name='map-idea-detail'),
 ]

--- a/euth/memberships/dashboard.py
+++ b/euth/memberships/dashboard.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.dashboard import DashboardComponent
 from adhocracy4.dashboard import components

--- a/euth/memberships/forms.py
+++ b/euth/memberships/forms.py
@@ -3,7 +3,7 @@ import re
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from euth.users.models import User
 

--- a/euth/memberships/projects_urls.py
+++ b/euth/memberships/projects_urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(r'^(?P<slug>[-\w_]+)/$', views.RequestsProjectDetailView.as_view(),
-        name='project-detail'),
+    re_path(r'^(?P<slug>[-\w_]+)/$', views.RequestsProjectDetailView.as_view(),
+            name='project-detail'),
 ]

--- a/euth/memberships/urls.py
+++ b/euth/memberships/urls.py
@@ -1,20 +1,20 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(
+    re_path(
         r'^apply/(?P<project_slug>[-\w_]+)/$',
         views.RequestView.as_view(),
         name='memberships-request'
     ),
 
-    url(
+    re_path(
         r'^invites/(?P<invite_token>[-\w_]+)/$',
         views.InviteDetailView.as_view(),
         name='membership-invite-detail'
     ),
-    url(
+    re_path(
         r'^invites/(?P<invite_token>[-\w_]+)/accept/$',
         views.InviteUpdateView.as_view(),
         name='membership-invite-update'

--- a/euth/memberships/views.py
+++ b/euth/memberships/views.py
@@ -3,7 +3,7 @@ from django.contrib import messages
 from django.contrib.auth import mixins as mixin
 from django.http import Http404
 from django.shortcuts import redirect
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import generic
 from rules.contrib import views as rules_views
 

--- a/euth/offlinephases/dashboard.py
+++ b/euth/offlinephases/dashboard.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.dashboard import DashboardComponent
 from adhocracy4.dashboard import components

--- a/euth/offlinephases/forms.py
+++ b/euth/offlinephases/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.forms.fields import DateTimeField
 from euth.contrib import widgets

--- a/euth/offlinephases/models.py
+++ b/euth/offlinephases/models.py
@@ -3,7 +3,7 @@ from ckeditor_uploader.fields import RichTextUploadingField
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.utils import functional
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4 import transforms
 from adhocracy4.comments import models as comment_models

--- a/euth/offlinephases/urls.py
+++ b/euth/offlinephases/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
-    url(r'^(?P<pk>\d+)/$',
-        views.OfflineEventDetailView.as_view(), name='offlineevent-detail'),
+    path('<int:pk>/', views.OfflineEventDetailView.as_view(),
+         name='offlineevent-detail'),
 ]

--- a/euth/offlinephases/views.py
+++ b/euth/offlinephases/views.py
@@ -3,7 +3,7 @@ from django.db import transaction
 from django.shortcuts import redirect
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import generic
 from rules.contrib.views import PermissionRequiredMixin
 

--- a/euth/organisations/filters.py
+++ b/euth/organisations/filters.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.filters.filters import DefaultsFilterSet
 from adhocracy4.filters.filters import DistinctOrderingFilter

--- a/euth/organisations/models.py
+++ b/euth/organisations/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_countries import fields as countries_fields
 from parler.models import TranslatableManager
 from parler.models import TranslatableModel

--- a/euth/organisations/urls.py
+++ b/euth/organisations/urls.py
@@ -1,9 +1,11 @@
-from django.conf.urls import url
+from django.urls import path
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(r'^$', views.OrganisationListView.as_view(), name='organisation-list'),
-    url(r'^(?P<slug>[-\w_]+)/$',
-        views.OrganisationDetailView.as_view(), name='organisation-detail'),
+    path('', views.OrganisationListView.as_view(), name='organisation-list'),
+    re_path(r'^(?P<slug>[-\w_]+)/$',
+            views.OrganisationDetailView.as_view(),
+            name='organisation-detail'),
 ]

--- a/euth/organisations/views.py
+++ b/euth/organisations/views.py
@@ -1,6 +1,6 @@
 from django.contrib.messages.views import SuccessMessageMixin
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import generic
 
 from adhocracy4.dashboard import mixins as a4dashboard_mixins

--- a/euth/projects/dashboard.py
+++ b/euth/projects/dashboard.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.dashboard import DashboardComponent
 from adhocracy4.dashboard import components

--- a/euth/projects/filters.py
+++ b/euth/projects/filters.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.filters.filters import DefaultsFilterSet
 from adhocracy4.filters.filters import DistinctOrderingFilter

--- a/euth/projects/forms.py
+++ b/euth/projects/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.projects.models import Project
 from euth.users.fields import UserSearchField

--- a/euth/projects/overwrites.py
+++ b/euth/projects/overwrites.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.projects.enums import Access
 

--- a/euth/projects/templatetags/time_delta_tags.py
+++ b/euth/projects/templatetags/time_delta_tags.py
@@ -1,6 +1,6 @@
 from django import template
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 register = template.Library()
 

--- a/euth/projects/urls.py
+++ b/euth/projects/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import url
+from django.urls import path
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(r'^project-delete/(?P<pk>[-\w_]+)/$',
-        views.ProjectDeleteView.as_view(),
-        name='project-delete'),
-    url(r'^$',
-        views.ProjectListView.as_view(), name='project-list')
+    re_path(r'^project-delete/(?P<pk>[-\w_]+)/$',
+            views.ProjectDeleteView.as_view(),
+            name='project-delete'),
+    path('', views.ProjectListView.as_view(), name='project-list')
 ]

--- a/euth/projects/views.py
+++ b/euth/projects/views.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views import generic
 from rules.contrib.views import PermissionRequiredMixin
 

--- a/euth/users/__init__.py
+++ b/euth/users/__init__.py
@@ -1,6 +1,6 @@
 from django.urls import Resolver404
 from django.urls import resolve
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 
 default_app_config = 'euth.users.apps.Config'
 
@@ -23,7 +23,9 @@ def sanitize_next(request):
 
     if url_name in _get_account_url_names():
         nextparam = request.GET.get('next') or request.POST.get('next')
-        next = nextparam if is_safe_url(nextparam, allowed_hosts=None) else '/'
+        next = nextparam \
+            if url_has_allowed_host_and_scheme(nextparam, allowed_hosts=None) \
+            else '/'
     else:
         next = request.get_full_path()
     return next

--- a/euth/users/adapters.py
+++ b/euth/users/adapters.py
@@ -2,7 +2,7 @@ import re
 from urllib.parse import quote
 
 from allauth.account.adapter import DefaultAccountAdapter
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from adhocracy4.emails import Email
 from adhocracy4.emails.mixins import SyncEmailMixin
@@ -23,8 +23,9 @@ class EuthAccountAdapter(DefaultAccountAdapter):
 
     def get_email_confirmation_url(self, request, emailconfirmation):
         url = super().get_email_confirmation_url(request, emailconfirmation)
-        if 'next' in request.POST and is_safe_url(request.POST['next'],
-                                                  allowed_hosts=None):
+        if 'next' in request.POST \
+            and url_has_allowed_host_and_scheme(request.POST['next'],
+                                                allowed_hosts=None):
             return '{}?next={}'.format(url, quote(request.POST['next']))
         else:
             return url
@@ -37,8 +38,9 @@ class EuthAccountAdapter(DefaultAccountAdapter):
         )
 
     def get_email_confirmation_redirect_url(self, request):
-        if 'next' in request.GET and is_safe_url(request.GET['next'],
-                                                 allowed_hosts=None):
+        if 'next' in request.GET \
+            and url_has_allowed_host_and_scheme(request.GET['next'],
+                                                allowed_hosts=None):
             return request.GET['next']
         else:
             return super().get_email_confirmation_redirect_url(request)

--- a/euth/users/admin.py
+++ b/euth/users/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.contrib import auth
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import models
 

--- a/euth/users/models.py
+++ b/euth/users/models.py
@@ -5,7 +5,7 @@ from django.core import validators
 from django.db import models
 from django.templatetags.static import static
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_countries import fields as countries_fields
 from pytz import common_timezones
 

--- a/euth/users/urls.py
+++ b/euth/users/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(r'^(?P<slug>[-\w _.@+-]+)/$', views.ProfileView.as_view(),
-        name='profile'),
+    re_path(r'^(?P<slug>[-\w _.@+-]+)/$', views.ProfileView.as_view(),
+            name='profile'),
 ]

--- a/euth_wagtail/settings/base.py
+++ b/euth_wagtail/settings/base.py
@@ -161,6 +161,8 @@ DATABASES = {
     }
 }
 
+# default primary key field
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 # Auth
 # https://docs.djangoproject.com/en/1.8/topics/auth/customizing/

--- a/euth_wagtail/settings/base.py
+++ b/euth_wagtail/settings/base.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)

--- a/euth_wagtail/urls.py
+++ b/euth_wagtail/urls.py
@@ -1,10 +1,11 @@
 from ckeditor_uploader import views as ck_views
 from django.conf import settings
-from django.conf.urls import include
-from django.conf.urls import url
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.contrib.auth.decorators import login_required
+from django.urls import include
+from django.urls import path
+from django.urls import re_path
 from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
 from django.views.i18n import JavaScriptCatalog
@@ -69,48 +70,45 @@ sitemaps = {
 }
 
 urlpatterns = [
-    url(r'^django-admin/', admin.site.urls),
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'^documents/', include(wagtaildocs_urls)),
-    url(r'^api/', include(router.urls)),
-    url(r'^api/', include(ct_router.urls)),
-    url(r'^api/', include(module_router.urls)),
-    url(r'^api/', include(question_router.urls)),
-    url(r'^upload/',
-        login_required(ck_views.upload), name='ckeditor_upload'),
-    url(r'^browse/',
-        never_cache(login_required(ck_views.browse)), name='ckeditor_browse'),
-    url(r'^robots\.txt$', TemplateView.as_view(
+    path('django-admin/', admin.site.urls),
+    path('admin/', include(wagtailadmin_urls)),
+    path('documents/', include(wagtaildocs_urls)),
+    path('api/', include(router.urls)),
+    path('api/', include(ct_router.urls)),
+    path('api/', include(module_router.urls)),
+    path('api/', include(question_router.urls)),
+    path('upload/', login_required(ck_views.upload), name='ckeditor_upload'),
+    path('browse/',
+         never_cache(login_required(ck_views.browse)), name='ckeditor_browse'),
+    re_path(r'^robots\.txt$', TemplateView.as_view(
         template_name='robots.txt',
         content_type="text/plain"), name="robots_file"),
 ]
 
 urlpatterns += i18n_patterns(
-    url(r'^accounts/', include(accounts_urls)),
-    url(r'^dashboard/', include(dashboard_urls)),
-    url(r'^profile/', include(user_urls)),
-    url(r'^orgs/', include(organisations_urls)),
-    url(r'^projects/', include(project_urls)),
-    url(r'^projects/', include(memberships_project_urls)),
-    url(r'^paragraphs/', include(paragraph_urls)),
-    url(r'^offlineevents/', include(offlinephases_urls)),
-    url(r'^ideas/', include(ideas_urls)),
-    url(r'^maps/', include(maps_urls)),
-    url(r'^memberships/', include(memberships_urls)),
-    url(r'^blueprints/', include(blueprints_urls)),
-    url(r'^jsi18n/$', JavaScriptCatalog.as_view(), name='javascript-catalog'),
-    url(r'^sitemap\.xml$',
-        wagtail_sitemap_views.index,
-        {'sitemaps': sitemaps, 'sitemap_url_name': 'sitemaps'}),
-    url(r'^sitemap-(?P<section>.+)\.xml$',
-        wagtail_sitemap_views.sitemap,
-        {'sitemaps': sitemaps}, name='sitemaps'),
-    url(r'^communitydebate/', include(communitydebate_urls)),
-    url(r'', include(wagtail_urls)),
+    path('accounts/', include(accounts_urls)),
+    path('dashboard/', include(dashboard_urls)),
+    path('profile/', include(user_urls)),
+    path('orgs/', include(organisations_urls)),
+    path('projects/', include(project_urls)),
+    path('projects/', include(memberships_project_urls)),
+    path('paragraphs/', include(paragraph_urls)),
+    path('offlineevents/', include(offlinephases_urls)),
+    path('ideas/', include(ideas_urls)),
+    path('maps/', include(maps_urls)),
+    path('memberships/', include(memberships_urls)),
+    path('blueprints/', include(blueprints_urls)),
+    path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
+    re_path(r'^sitemap\.xml$', wagtail_sitemap_views.index,
+            {'sitemaps': sitemaps, 'sitemap_url_name': 'sitemaps'}),
+    re_path(r'^sitemap-(?P<section>.+)\.xml$', wagtail_sitemap_views.sitemap,
+            {'sitemaps': sitemaps}, name='sitemaps'),
+    path('communitydebate/', include(communitydebate_urls)),
+    path('', include(wagtail_urls)),
 )
 
 urlpatterns += [
-    url(r'^accounts/', include(urls_accounts)),
+    path('accounts/', include(urls_accounts)),
 ]
 
 if settings.DEBUG:
@@ -125,7 +123,7 @@ if settings.DEBUG:
         pass
     else:
         urlpatterns += [
-            url(r'^__debug__/', include(debug_toolbar.urls)),
+            path('__debug__/', include(debug_toolbar.urls)),
         ]
 
     urlpatterns += staticfiles_urlpatterns()

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": "https://github.com/liqd/euth_wagtail.git",
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.15.4",
-    "adhocracy4": "github:liqd/adhocracy4#opin-v2110",
+    "adhocracy4": "github:liqd/adhocracy4#db606bfb85f5af3e6c0cb13b1ce723adba681091",
     "axios": "0.21.4",
     "bootstrap": "5.0.2",
     "css-loader": "6.2.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@opin-v2110#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@db606bfb85f5af3e6c0cb13b1ce723adba681091#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ git+git://github.com/liqd/adhocracy4.git@opin-v2110#egg=adhocracy4
 # Additional requirements
 bcrypt==3.2.0
 brotli==1.0.9
-django-cloudflare-push==0.2.0
+django-cloudflare-push==0.2.1
 django-countries==7.3.1
 django-sites==0.11
 django-parler==2.3
@@ -13,12 +13,12 @@ micawber==0.5.3
 pyuca==1.2
 raven==6.10.0
 Unidecode==1.3.3 # needed by django-autoslug for cyrillic fields
-wagtail==2.11.9 # pyup: <2.12
+wagtail==2.16.1
 whitenoise==6.0.0
 
 # Inherited a4-core requirements
 bleach==4.1.0
-Django==2.2.27 # pyup: <2.3
+Django==3.2.12 # pyup: <3.3
 django-allauth==0.49.0
 django-autoslug==1.9.8
 django-background-tasks==1.2.5


### PR DESCRIPTION
I did not update A4 to the newest version as [this commit](https://github.com/liqd/adhocracy4/commit/624297f51948db66fc77c28cdbf59fc73197e3e2) seems to break the ProjectAdminForm (I think because there are no project topics in opin). Did not have the brain so fix that tonight, but will do tomorrow and thought we could merge already, so others can go on..

Also, the wagtail migration thing was not a problem (see [here](https://github.com/liqd/adhocracy-plus/pull/1528/commits/5b16a011cd926ecfb9bc104ad55e617af1f61b1f)), i.e. its installing on both empty and filled databases or did I miss something? So I did not add that to the create_homepage migration..  but could you double check @fuzzylogic2000 that its working? 