### PR TITLE
dashboard/moderators: queryselecting input checkboxes fixed

### DIFF
--- a/euth/dashboard/static/user_list/react_user_list.jsx
+++ b/euth/dashboard/static/user_list/react_user_list.jsx
@@ -47,7 +47,7 @@ class UserList extends React.Component {
   }
 
   submitHandler (e) {
-    const checkedUsers = this.userlistRef.querySelectorAll(':checked')
+    const checkedUsers = this.userlistRef.current.querySelectorAll(':checked')
     const idsToBeActedOn = Array.prototype.map.call(checkedUsers,
       user => parseInt(user.dataset.userid)
     )


### PR DESCRIPTION
not sure where to ask this, but I just saw in this file we use jQuery. Do we want to get rid of it here at some point? Shall I create an issue or even a task in our technical backlog?

Another thing that I saw is how the Userlist is getting "injected" via template tags. I am not totally sure what it does or how it works. Maybe a refactor here could reduce complexity as well?
see:
https://github.com/liqd/a4-opin/blob/d4cd69a053765105292bad545e89be43027012ea/euth/dashboard/static/user_list/react_user_list.jsx#L113
