### PR TITLE
communitydebate/views: do not re validate upload forms if they were i…

### DIFF
--- a/euth/communitydebate/views.py
+++ b/euth/communitydebate/views.py
@@ -95,8 +95,9 @@ class TopicCreateView(PermissionRequiredMixin, generic.CreateView):
                                        'successfully created'))
                 return response
 
-        upload_forms = forms.TopicFileUploadFormset(request.POST,
-                                                    request.FILES)
+        else:
+            upload_forms = forms.TopicFileUploadFormset(request.POST,
+                                                        request.FILES)
         return render(request, self.template_name,
                       self.get_context_data(upload_forms=upload_forms))
 


### PR DESCRIPTION
…nvalid

fixes #2058

Problem was, that when the upload_form was invalid, a new upload_form instance was initialized that was then validated again (happens somewhere along the render), so that is where the second validation came from @fuzzylogic2000. And by then the file somehow gets lost, I guess this is also related to the file not being there anymore if validation fails (as for images), but I dont fully get what is happening there..