### PR TITLE
Remove unused dependencies 'django-bower' and 'six' from 'requirements/dev.txt' & 'setup.py'

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,4 +10,3 @@ pytest-cov==4.0.0
 pytest-django==4.5.2
 pytest-factoryboy==2.5.1
 pytest==7.2.1
-six==1.16.0

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,4 @@ setup(name='euth_wagtail',
       install_requires=[
           'Django',
           'wagtail',
-          'django_bower'
       ])


### PR DESCRIPTION
As part of our ongoing research on Python dependency management, we identified a potential improvement in your project’s approach.

Specifically, the dependencies `django-bower` and `six` are listed in `requirements/dev.txt` and `setup.py` repsectively, but don’t appear to be used anywhere in the codebase.

In the case of `six`, it seems to have been added as a workaround to support `transifex-client`, rather than being required by the application code itself. However, `transifex-client` was removed from the project in March 2022 (commit f90991e3).

Timeline Analysis:
- March 2019: 28720ceb - Added `six==1.11.0` to make `transifex` work
- March 2022: f90991e3 - Removed deprecated `transifex-client`

Cleaning them up can make your project easier to maintain and a bit safer in the long run.

Hope this is helpful!